### PR TITLE
removed prefix from available command list

### DIFF
--- a/src/main/java/com/sulphate/chatcolor2/commands/ChatColorCommand.java
+++ b/src/main/java/com/sulphate/chatcolor2/commands/ChatColorCommand.java
@@ -96,8 +96,8 @@ public class ChatColorCommand implements CommandExecutor {
                         String modifierString = buildCharacterColourString(availableModifiers);
 
                         s.sendMessage(M.PREFIX + M.AVAILABLE_COLORS);
-                        s.sendMessage(GeneralUtils.colourise(" &7- &e" + M.PREFIX + M.COLORS + ": " + colourString));
-                        s.sendMessage(GeneralUtils.colourise(" &7- &e" + M.PREFIX + M.MODIFIERS + ": " + modifierString));
+                        s.sendMessage(GeneralUtils.colourise(" &7- &e" + M.COLORS + ": " + colourString));
+                        s.sendMessage(GeneralUtils.colourise(" &7- &e" + M.MODIFIERS + ": " + modifierString));
                         s.sendMessage(M.PREFIX + (checkPermission(s, "chatcolor.use-hex-codes") ? M.HEX_ACCESS : M.NO_HEX_PERMISSIONS));
 
                         return true;


### PR DESCRIPTION
No need to display the prefix here. Causes situations like this: https://monosnap.com/file/epUkRs3JJnApFyUr3Z223pN6L1luuS