### PR TITLE
Add modify-chat setting

### DIFF
--- a/src/main/java/com/sulphate/chatcolor2/listeners/ChatListener.java
+++ b/src/main/java/com/sulphate/chatcolor2/listeners/ChatListener.java
@@ -22,6 +22,10 @@ public class ChatListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEvent(AsyncPlayerChatEvent e) {
+        if (!(boolean) configUtils.getSetting("modify-chat")) {
+            return;
+        }
+
         Player player = e.getPlayer();
         String message = e.getMessage();
         UUID uuid = player.getUniqueId();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,7 @@ settings:
   command-name: 'chatcolor'
   force-group-colors: true
   default-color-enabled: true
+  modify-chat: true
 default:
   code: '1'
   color: '&f'


### PR DESCRIPTION
This PR adds a setting "modify-chat" which checks whether the plugin should listen and make changes to a message on AsyncPlayerChatEvent

Haven't tested yet but I don't see why this shouldn't work