### PR TITLE
Ignored color event to prevent interference  from other plugins

### DIFF
--- a/src/main/java/com/sulphate/chatcolor2/listeners/ChatListener.java
+++ b/src/main/java/com/sulphate/chatcolor2/listeners/ChatListener.java
@@ -20,7 +20,7 @@ public class ChatListener implements Listener {
         this.generalUtils = generalUtils;
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEvent(AsyncPlayerChatEvent e) {
         Player player = e.getPlayer();
         String message = e.getMessage();


### PR DESCRIPTION
This fix is for preventing conflicts with other plugins while reading chat input. I was making a plugin to read chat inputs as and parse then and found out that this plugin was constantly changing the input even if the AsyncPlayerChatEvent was cancelled.