### PR TITLE
Maven: fix "blocked mirror for repositories" error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Maven versions 3.8.1 and above block http repositories for security
reasons. This error can be fixed simply by changing the repository URL
to use https instead of http