### PR TITLE
Fix version parsing for modern server versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 *.iml
 dependency-reduced-pom.xml
 .idea/
+.DS_Store

--- a/src/main/java/com/sulphate/chatcolor2/main/ChatColor.java
+++ b/src/main/java/com/sulphate/chatcolor2/main/ChatColor.java
@@ -132,11 +132,22 @@ public class ChatColor extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        guiManager.closeOpenGuis();
-        playerDataStore.shutdown();
+        if (guiManager != null) {
+            guiManager.closeOpenGuis();
+        }
+
+        if (playerDataStore != null) {
+            playerDataStore.shutdown();
+        }
+
         plugin = null;
 
-        console.sendMessage(M.PREFIX + M.SHUTDOWN.replace("[version]", getDescription().getVersion()));
+        if (M != null) {
+            console.sendMessage(M.PREFIX + M.SHUTDOWN.replace("[version]", getDescription().getVersion()));
+        }
+        else {
+            console.sendMessage(GeneralUtils.colourise("&b[ChatColor] &eChatColor 2 Version &b" + getDescription().getVersion() + " &ehas been &cdisabled&e."));
+        }
     }
 
     private void setupObjects() {

--- a/src/main/java/com/sulphate/chatcolor2/utils/CompatabilityUtils.java
+++ b/src/main/java/com/sulphate/chatcolor2/utils/CompatabilityUtils.java
@@ -5,9 +5,13 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 // Utils for managing cross-api-version compatability.
 public class CompatabilityUtils {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+(?:\\.\\d+)+)");
 
     private static boolean isMaterialLegacy;
     private static boolean isHexLegacy;
@@ -19,14 +23,7 @@ public class CompatabilityUtils {
     }
 
     public static void init() {
-        // Parse minor version to check for hex compatability.
-        String version = Bukkit.getBukkitVersion();
-        version = version.substring(0, version.indexOf('-'));
-
-        int dotIndex = version.indexOf('.');
-        float minorVersion = Float.parseFloat(version.substring(dotIndex + 1));
-
-        isHexLegacy = minorVersion < 16;
+        isHexLegacy = isHexLegacyVersion(Bukkit.getBukkitVersion());
         isMaterialLegacy = Material.getMaterial("INK_SAC") == null;
 
         blockColourToDataMap = new HashMap<>();
@@ -41,6 +38,41 @@ public class CompatabilityUtils {
         for (int i = 0; i < dyeColourNames.length; i++) {
             dyeColourToDataMap.put(dyeColourNames[i], (short) i);
         }
+    }
+
+    private static boolean isHexLegacyVersion(String version) {
+        int[] versionParts = parseVersionParts(version);
+
+        if (versionParts.length < 2) {
+            return false;
+        }
+
+        return versionParts[0] == 1 && versionParts[1] < 16;
+    }
+
+    private static int[] parseVersionParts(String version) {
+        if (version == null) {
+            return new int[0];
+        }
+
+        Matcher matcher = VERSION_PATTERN.matcher(version);
+        if (!matcher.find()) {
+            return new int[0];
+        }
+
+        String[] rawParts = matcher.group(1).split("\\.");
+        int[] versionParts = new int[rawParts.length];
+
+        for (int i = 0; i < rawParts.length; i++) {
+            try {
+                versionParts[i] = Integer.parseInt(rawParts[i]);
+            }
+            catch (NumberFormatException ex) {
+                return new int[0];
+            }
+        }
+
+        return versionParts;
     }
 
     public static ItemStack getColouredItem(String materialName) {


### PR DESCRIPTION
It fixes https://github.com/sulphi-fox/ChatColor2/issues/33 

tbh, It was done by ChatGPT 5.5 codex and verified on my public paper 26.1.2 server 